### PR TITLE
Offline Prefetch And Config

### DIFF
--- a/mustang_codegen/build.yaml
+++ b/mustang_codegen/build.yaml
@@ -25,6 +25,13 @@ builders:
         include: ['**/models/*.dart']
       }
     }
+  offline_service_builder:
+    import: 'package:mustang_codegen/builder.dart'
+    builder_factories: [ 'offlineSerializerBuilder' ]
+    build_extensions: { '.dart': [ '.ser.dart' ] }
+    auto_apply: root_package
+    build_to: source
+    runs_before: [ 'built_value_generator:built_value' ]
   app_serializer_builder:
     import: 'package:mustang_codegen/builder.dart'
     builder_factories: [ 'appSerializerBuilder' ]

--- a/mustang_codegen/lib/builder.dart
+++ b/mustang_codegen/lib/builder.dart
@@ -2,6 +2,7 @@ import 'package:build/build.dart';
 import 'package:mustang_codegen/src/app_serializer_builder.dart';
 import 'package:mustang_codegen/src/aspect_generator/app_aspect_generator.dart';
 import 'package:mustang_codegen/src/model_generator/app_model_generator.dart';
+import 'package:mustang_codegen/src/offline_service_builder.dart';
 import 'package:mustang_codegen/src/screen_generator/screen_generator.dart';
 import 'package:mustang_codegen/src/service_generator/screen_service_generator.dart';
 import 'package:mustang_codegen/src/state_generator/screen_state_generator.dart';
@@ -33,3 +34,5 @@ Builder screenLibraryBuilder(BuilderOptions options) => LibraryBuilder(
     );
 
 Builder appSerializerBuilder(BuilderOptions options) => AppSerializerBuilder();
+
+Builder offlineSerializerBuilder(BuilderOptions options) => OfflineServiceBuilder();

--- a/mustang_codegen/lib/src/offline_service_builder.dart
+++ b/mustang_codegen/lib/src/offline_service_builder.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:build/build.dart';
+import 'package:glob/glob.dart';
+import 'package:mustang_codegen/src/utils.dart';
+import 'package:source_gen/source_gen.dart';
+
+class OfflineServiceBuilder extends Builder {
+  static const String _sharedServicePath = 'src/shared_services';
+  static const String _offlineServicePathFromRoot = 'lib/$_sharedServicePath';
+  static const String _offlineServicePath = 'offline_service.dart';
+
+  @override
+  Map<String, List<String>> get buildExtensions {
+    return const {
+      r'$lib$': ['$_sharedServicePath/$_offlineServicePath'],
+    };
+  }
+
+  @override
+  FutureOr<void> build(BuildStep buildStep) async {
+    List<String> screens = Utils.getOfflinePreFetchScreens();
+    _validate(buildStep, screens);
+    List<String> imports = [];
+    List<String> getDataForScreens = [];
+    if (screens.isNotEmpty) {
+      for (String screen in screens) {
+        await for (AssetId assetId
+            in buildStep.findAssets(Glob('lib/src/screens/**/*_screen.dart'))) {
+          LibraryElement library = await buildStep.resolver.libraryFor(assetId);
+          String screenName = library.topLevelElements.first.name ?? '';
+          if (library.source.uri.path.contains('/$screen.dart')) {
+            String screenUri = '${library.source.uri}';
+            String servicePath = screenUri.replaceFirst(
+              screen,
+              '${Utils.screenFile2GenServiceFile(screen)}.service',
+            );
+            imports.add("import '$servicePath';");
+            getDataForScreens.add(
+                'await ${Utils.screenClass2GenServiceClass(screenName)}().memoizedGetData();');
+          }
+        }
+      }
+    }
+
+    if (getDataForScreens.isNotEmpty) {
+      // get the current app package
+      String pkgName = buildStep.inputId.package;
+      AssetId outFile =
+          AssetId(pkgName, '$_offlineServicePathFromRoot/$_offlineServicePath');
+
+      String out = _generate(imports, getDataForScreens);
+
+      await buildStep.writeAsString(outFile, out);
+    }
+  }
+
+  static String _generate(
+    List<String> imports,
+    List<String> getDataForScreens,
+  ) {
+    return '''
+${imports.join('\n')}
+
+class OfflineService {
+  static Future<void> preFetch() async {
+    ${getDataForScreens.join('\n    ')}
+  }
+}
+    ''';
+  }
+
+  Future<void> _validate(BuildStep buildStep, List<String> screens) async {
+    List<String> existingScreens = [];
+    await for (AssetId assetId
+        in buildStep.findAssets(Glob('lib/src/screens/**/*_screen.dart'))) {
+      LibraryElement library = await buildStep.resolver.libraryFor(assetId);
+      String screenName =
+          library.source.uri.path.split('/').last.split('.').first;
+      existingScreens.add(screenName);
+    }
+
+    List<String> incorrectScreenNames =
+        screens.where((element) => !existingScreens.contains(element)).toList();
+    if (incorrectScreenNames.isNotEmpty) {
+      throw InvalidGenerationSourceError(
+        'Could not find the following screens: $incorrectScreenNames\nHint: Fix the name in mustang.yaml \$',
+        todo: 'Prefix class name with \$',
+      );
+    }
+  }
+}

--- a/mustang_codegen/lib/src/service_generator/screen_service_generator.dart
+++ b/mustang_codegen/lib/src/service_generator/screen_service_generator.dart
@@ -251,16 +251,18 @@ class ScreenServiceGenerator extends Generator {
         void clearMemoizedScreen({
           reload = true,
         }) {
-          MustangStore.delete<_\$${screenState}Cache>();
-          if (kDebugMode) {
-            postEvent('${Utils.debugEventKind}', {
-              'modelName': '\${_\$${screenState}Cache}',
-              'modelStr': '{}',
-            });
-          }
-          $screenState screenState = MustangStore.get<$screenState>()!;
-          if (reload) { 
-              screenState.update();
+          if(!MustangStore.getOfflineStatus) {
+            MustangStore.delete<_\$${screenState}Cache>();
+            if (kDebugMode) {
+              postEvent('${Utils.debugEventKind}', {
+                'modelName': '\${_\$${screenState}Cache}',
+                'modelStr': '{}',
+              });
+            }
+            $screenState screenState = MustangStore.get<$screenState>()!;
+            if (reload) { 
+                screenState.update();
+            }
           }    
         }
         

--- a/mustang_codegen/lib/src/utils.dart
+++ b/mustang_codegen/lib/src/utils.dart
@@ -13,7 +13,9 @@ class Utils {
 
   // Keys in mustang-cli.yaml
   static const String serializerKey = 'serializer';
+  static const String preFetchKey = 'prefetch';
   static const String screenKey = 'screen';
+  static const String screensKey = 'screens';
   static const String screenImportsKey = 'imports';
 
   static String class2File(String className) {
@@ -55,6 +57,22 @@ class Utils {
       return (m.group(1)?.toUpperCase() ?? '');
     });
     return capitalizeFirst(firstPass);
+  }
+
+  static String screenClass2GenServiceClass(String screenClassName) {
+    String screenFileName = class2File(screenClassName);
+    String genServiceFileName =
+    screenFileName.replaceFirst(RegExp('_screen\$'), '_service');
+    String firstPass =
+    genServiceFileName.replaceAllMapped(RegExp('_([a-z])'), (Match m) {
+      return (m.group(1)?.toUpperCase() ?? '');
+    });
+    return capitalizeFirst(firstPass);
+  }
+
+  static String screenFile2GenServiceFile(String screenClassName) {
+    String screenFileName = class2File(screenClassName);
+    return screenFileName.replaceFirst(RegExp('_screen\$'), '_service');
   }
 
   static String class2Var(String className) {
@@ -105,6 +123,22 @@ class Utils {
         .map((importElement) =>
             '${importElement.importedLibrary?.definingCompilationUnit.declaration ?? ''}')
         .toList();
+  }
+
+  static List<String> getOfflinePreFetchScreens() {
+    String configFilePath = p.join(p.current, configFile);
+    if (configFilePath.isNotEmpty && File(configFilePath).existsSync()) {
+      File configFile = File(configFilePath);
+      String rawConfig = configFile.readAsStringSync();
+
+      dynamic yamlConfig = loadYaml(rawConfig);
+      if (yamlConfig[preFetchKey] != null) {
+        if(yamlConfig[preFetchKey][screensKey] != null) {
+          return List<String>.from(yamlConfig[preFetchKey][screensKey]);
+        }
+      }
+    }
+    return <String>[];
   }
 
   static String? getCustomSerializerPackage() {

--- a/mustang_core/lib/src/store/mustang_store.dart
+++ b/mustang_core/lib/src/store/mustang_store.dart
@@ -19,6 +19,14 @@ class MustangStore {
   // Hive Box Name to store the model data
   static String? hiveBox;
 
+  static bool _offline = false;
+
+  static get getOfflineStatus => _offline;
+
+  static void toggleOfflineStatus() {
+    _offline = !_offline;
+  }
+
   /// Looks up instance of type [T], if exists. Returns null if instance of
   /// type [T] is not found.
   static T? get<T>() {
@@ -99,9 +107,11 @@ class MustangStore {
   static void config({
     bool isPersistent = false,
     String? storeName,
+    bool offline = false,
   }) async {
     persistent = isPersistent;
     hiveBox = storeName;
+    _offline = offline;
   }
 
   /// Writes serialized object to a file


### PR DESCRIPTION
Add screens to prefetch in `mustang.yaml` at the root of your project
```yaml
serializer: package:wrench_flutter_common/flutter_common.dart
screen:
  imports:
    - package:wrench_widgets/widgets.dart
  progress_widget: WrenchProgressIndicatorScreen()
  error_widget: WrenchErrorWithDescriptionScreen()
prefetch:
  screens:
    - job_details_screen
    - verify_update_vehicle_screen
    - checklist_screen
    - add_photos_screen
```

**Generated Offline Service**
```dart
import 'package:app2/src/screens/route_screens/job_details/job_details_service.service.dart';
import 'package:app2/src/screens/route_screens/verify_update_vehicle/verify_update_vehicle_service.service.dart';
import 'package:app2/src/screens/route_screens/checklist/checklist_service.service.dart';
import 'package:app2/src/screens/route_screens/add_photos/add_photos_service.service.dart';

class OfflineService {
  static Future<void> preFetch() async {
    await JobDetailsService().memoizedGetData();
    await VerifyUpdateVehicleService().memoizedGetData();
    await ChecklistService().memoizedGetData();
    await AddPhotosService().memoizedGetData();
  }
}
    
```